### PR TITLE
Persist ipv4 and ipv6 iptables rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The below table specifies the versions of role available on [Ansible Galaxy](htt
 CIS Ubuntu 20.04 Benchmark Version | Ansible Galaxy Version | Repository Tag Version
 ---------------------------------- | ---------------------- | ----------------------
 1.0.0                              | 1.0.0, 1.0.1, 1.0.2    | 1.0.0, 1.0.1, 1.0.2
-1.1.0                              | 2.0.0, 2.0.1           | 2.0.0, 2.0.1
+1.1.0                              | 2.0.0, 2.0.1, 2.1.0    | 2.0.0, 2.0.1, 2.1.0
 
 ## 1\. Installation/Download Instructions:
 
@@ -30,10 +30,10 @@ This role is available on Ansible Galaxy. There are a few methods you can utiliz
   ansible-galaxy install darkwizard242.cis_ubuntu_2004
   ```
 
-- Installing/Downloading specific available tag version (using 2.0.0 as an example):
+- Installing/Downloading specific available tag version (using 2.1.0 as an example):
 
   ```shell
-  ansible-galaxy install darkwizard242.cis_ubuntu_2004,2.0.0
+  ansible-galaxy install darkwizard242.cis_ubuntu_2004,2.1.0
   ```
 
 - Installing/Downloading specific available branch version from repository (using `master` branch as an example, `master` will always be compliant to latest available version of **CIS Ubuntu 20.04 Benchmark**):
@@ -68,7 +68,7 @@ Add to an existing **requirements.yml** file along with your other roles or crea
 
   ```yaml
   - name: darkwizard242.cis_ubuntu_2004
-    version: 2.0.0
+    version: 2.1.0
   ```
 
 - Specific branch from repository.

--- a/defaults/main/section_03.yml
+++ b/defaults/main/section_03.yml
@@ -526,3 +526,13 @@ ubuntu_2004_cis_section3_rule_3_5_3_3_4_params_output_connections_ipversion: ipv
 ubuntu_2004_cis_section3_rule_3_5_3_3_4_params_output_connections_protocols:
   - tcp
   - udp
+
+
+# Variables for Section 3 | IPtables | Extended Task 1
+ubuntu_2004_cis_section3_iptables_ext_1: true
+
+ubuntu_2004_cis_section3_iptables_ext_1_params_source: section_03/iptables_drop_rules.v6.j2
+ubuntu_2004_cis_section3_iptables_ext_1_params_dest: /etc/iptables/rules.v6
+ubuntu_2004_cis_section3_iptables_ext_1_params_owner: root
+ubuntu_2004_cis_section3_iptables_ext_1_params_group: root
+ubuntu_2004_cis_section3_iptables_ext_1_params_mode: '0644'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -76,3 +76,13 @@
     name: sshd
     enabled: yes
     state: restarted
+
+- name: persist iptables v4 rules
+  shell: iptables-save > /etc/iptables/rules.v4
+  args:
+    executable: /bin/bash
+
+- name: persist iptables v6 rules
+  shell: iptables-save > /etc/iptables/rules.v6
+  args:
+    executable: /bin/bash

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -83,6 +83,6 @@
     executable: /bin/bash
 
 - name: persist iptables v6 rules
-  shell: iptables-save > /etc/iptables/rules.v6
+  shell: ip6tables-save > /etc/iptables/rules.v6
   args:
     executable: /bin/bash

--- a/tasks/section_03.yml
+++ b/tasks/section_03.yml
@@ -878,6 +878,8 @@
         jump: "{{ ubuntu_2004_cis_section3_rule_3_5_3_2_1_params_iptablesloopbackchain_inputlocal_jump }}"
         source: "{{ ubuntu_2004_cis_section3_rule_3_5_3_2_1_params_iptablesloopbackchain_inputlocal_interface }}"
 
+  notify:
+    - persist iptables v4 rules
   when:
     - ubuntu_2004_cis_firewall == "iptables"
     - ubuntu_2004_cis_section3_rule_3_5_3_2_1
@@ -907,6 +909,8 @@
         protocol: "{{ item }}"
       with_items: "{{ ubuntu_2004_cis_section3_rule_3_5_3_2_2_params_output_connections_protocols }}"
 
+  notify:
+    - persist iptables v4 rules
   when:
     - ubuntu_2004_cis_firewall == "iptables"
     - ubuntu_2004_cis_section3_rule_3_5_3_2_2
@@ -937,6 +941,8 @@
         protocol: "{{ item }}"
       with_items: "{{ ubuntu_2004_cis_section3_rule_3_5_3_2_4_params_output_connections_protocols }}"
 
+  notify:
+    - persist iptables v4 rules
   when:
     - ubuntu_2004_cis_firewall == "iptables"
     - ubuntu_2004_cis_section3_rule_3_5_3_2_4
@@ -967,6 +973,8 @@
         policy: "{{ ubuntu_2004_cis_section3_rule_3_5_3_2_3_params_iptableschain_forward_policy }}"
       when: ubuntu_2004_cis_section3_rule_iptables_ipv4_default_deny_forward
 
+  notify:
+    - persist iptables v4 rules
   when:
     - ubuntu_2004_cis_firewall == "iptables"
     - ubuntu_2004_cis_section3_rule_3_5_3_2_3
@@ -1000,6 +1008,8 @@
         source: "{{ ubuntu_2004_cis_section3_rule_3_5_3_3_1_params_iptablesloopbackchain_inputlocal_interface }}"
         ip_version: "{{ ubuntu_2004_cis_section3_rule_3_5_3_3_1_params_iptablesloopbackchain_inputlocal_ipversion }}"
 
+  notify:
+    - persist iptables v6 rules
   when:
     - ubuntu_2004_cis_require_ipv6
     - ubuntu_2004_cis_firewall == "iptables"
@@ -1032,6 +1042,8 @@
         protocol: "{{ item }}"
       with_items: "{{ ubuntu_2004_cis_section3_rule_3_5_3_3_2_params_output_connections_protocols }}"
 
+  notify:
+    - persist iptables v6 rules
   when:
     - ubuntu_2004_cis_require_ipv6
     - ubuntu_2004_cis_firewall == "iptables"
@@ -1066,6 +1078,8 @@
         ip_version: "{{ ubuntu_2004_cis_section3_rule_3_5_3_3_3_params_iptableschain_forward_ipversion }}"
       when: ubuntu_2004_cis_section3_rule_iptables_ipv6_default_deny_forward
 
+  notify:
+    - persist iptables v6 rules
   when:
     - ubuntu_2004_cis_require_ipv6
     - ubuntu_2004_cis_firewall == "iptables"
@@ -1099,6 +1113,8 @@
         protocol: "{{ item }}"
       with_items: "{{ ubuntu_2004_cis_section3_rule_3_5_3_3_4_params_output_connections_protocols }}"
 
+  notify:
+    - persist iptables v6 rules
   when:
     - ubuntu_2004_cis_require_ipv6
     - ubuntu_2004_cis_firewall == "iptables"

--- a/tasks/section_03.yml
+++ b/tasks/section_03.yml
@@ -1124,3 +1124,22 @@
     - section3
     - rule_3_5_3_3_4
     - level_1
+
+
+## Following is a custom task to ensure that IPv6 DROP rules are present when IPv6 is not required i.e 'ubuntu_2004_cis_require_ipv6: false' and firewall is iptables i.e. 'ubuntu_2004_cis_firewall: iptables'
+## REFERENCE: https://github.com/darkwizard242/cis_ubuntu_2004/issues/9#issuecomment-925172069
+- name: "Ensure ipv6 DROP rules are present when firewall is 'iptables' and 'ipv6' is disabled"
+  template:
+    src: "{{ ubuntu_2004_cis_section3_iptables_ext_1_params_source }}"
+    dest: "{{ ubuntu_2004_cis_section3_iptables_ext_1_params_dest }}"
+    owner: "{{ ubuntu_2004_cis_section3_iptables_ext_1_params_owner }}"
+    group: "{{ ubuntu_2004_cis_section3_iptables_ext_1_params_group }}"
+    mode: "{{ ubuntu_2004_cis_section3_iptables_ext_1_params_mode }}"
+  when:
+    - not ubuntu_2004_cis_require_ipv6
+    - ubuntu_2004_cis_firewall == "iptables"
+    - ubuntu_2004_cis_section3_iptables_ext_1
+    - ubuntu_2004_cis_section3
+  tags:
+    - section3
+    - level_1

--- a/templates/section_03/iptables_drop_rules.v6.j2
+++ b/templates/section_03/iptables_drop_rules.v6.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
+COMMIT


### PR DESCRIPTION
- Fix for iptables rules not persisting as Identified and reported by @estenrye in #9 
- Addition of a task to run with ipv6 drop rules when ipv6 is not required ( `ubuntu_2004_cis_require_ipv6: false` ) and firewall is set to be iptables ( `ubuntu_2004_cis_firewall: iptables` ).