### PR TITLE
Improve package "absent" checking for services

### DIFF
--- a/defaults/main/section_02.yml
+++ b/defaults/main/section_02.yml
@@ -66,7 +66,11 @@ ubuntu_2004_cis_section2_rule_2_1_3_params_package_purge: yes
 # Variables for 2.1.4
 ubuntu_2004_cis_section2_rule_2_1_4: true
 
-ubuntu_2004_cis_section2_rule_2_1_4_params_package_name: cups
+ubuntu_2004_cis_section2_rule_2_1_4_params_package_name: 
+  - cups
+  - cups-common
+  - cups-server-common
+  - cups-daemon
 ubuntu_2004_cis_section2_rule_2_1_4_params_package_state: absent
 ubuntu_2004_cis_section2_rule_2_1_4_params_package_purge: yes
 
@@ -101,14 +105,20 @@ ubuntu_2004_cis_section2_rule_2_1_8_params_package_purge: yes
 # Variables for 2.1.9
 ubuntu_2004_cis_section2_rule_2_1_9: true
 
-ubuntu_2004_cis_section2_rule_2_1_9_params_package_name: vsftpd
+ubuntu_2004_cis_section2_rule_2_1_9_params_package_name: 
+  - vsftpd
+  - proftpd-basic
 ubuntu_2004_cis_section2_rule_2_1_9_params_package_state: absent
 ubuntu_2004_cis_section2_rule_2_1_9_params_package_purge: yes
 
 # Variables for 2.1.10
 ubuntu_2004_cis_section2_rule_2_1_10: true
 
-ubuntu_2004_cis_section2_rule_2_1_10_params_package_name: apache2
+ubuntu_2004_cis_section2_rule_2_1_10_params_package_name: 
+  - apache
+  - apache2
+  - lighttpd
+  - nginx
 ubuntu_2004_cis_section2_rule_2_1_10_params_package_state: absent
 ubuntu_2004_cis_section2_rule_2_1_10_params_package_purge: yes
 

--- a/tasks/section_04.yml
+++ b/tasks/section_04.yml
@@ -452,6 +452,7 @@
     owner: "{{ ubuntu_2004_cis_section4_rule_4_2_1_3_params_owner }}"
     group: "{{ ubuntu_2004_cis_section4_rule_4_2_1_3_params_group }}"
     mode: "{{ ubuntu_2004_cis_section4_rule_4_2_1_3_params_mode }}"
+    backup: yes
   notify:
     - rsyslog restart
   when:

--- a/templates/section_04/4.2.1.3_50-default.conf.j2
+++ b/templates/section_04/4.2.1.3_50-default.conf.j2
@@ -3,9 +3,7 @@
 auth,authpriv.*                 /var/log/auth.log
 *.*;auth,authpriv.none          -/var/log/syslog
 kern.*                          -/var/log/kern.log
-mail.*                          -/var/log/mail
-mail.info                       -/var/log/mail.info
-mail.warning                    -/var/log/mail.warn
+mail.*                          -/var/log/mail.log
 mail.err                        /var/log/mail.err
 news.crit                       -/var/log/news/news.crit
 news.err                        -/var/log/news/news.err


### PR DESCRIPTION
- Add well known http- and ftp servers packages to define as absent when checking for unneeded services.
- Add additional cups packages to uninstall, as only uninstalling "cups" will not stop the service.
