### PR TITLE
Fix 2.1.15 | CIS v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Changes/Fixes/Additions/Removals addressed in Releases. Dates are in MM/DD/YYYY format.
 
+## [2.1.0](https://github.com/darkwizard242/cis_ubuntu_2004/releases/tag/2.1.0) - 09/26/2021
+
+### Fixed
+
+- Fix for iptables rules not persisting as Identified and reported by @estenrye in Issue #9  | PR #10
+
+### Added
+
+- Addition of a task to run with ipv6 drop rules when ipv6 is not required ( `ubuntu_2004_cis_require_ipv6: false` ) and firewall is set to be iptables ( `ubuntu_2004_cis_firewall: iptables` )
+
+## [2.0.1](https://github.com/darkwizard242/cis_ubuntu_2004/releases/tag/2.0.1) - 09/21/2021
+
+### Fixed
+
+- Fix incorrect vars/tags reference in task for Control 3.5.3.2.3 of **CIS Benchmark for Ubuntu Linux 20.04 LTS v1.1.0**, identified by @estenrye #7
+
+
 ## [2.0.0](https://github.com/darkwizard242/cis_ubuntu_2004/releases/tag/2.0.0) - 07/15/2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ ubuntu_2004_cis_require_squid_server: false
 # Set to `true` if SNMP server is required.
 ubuntu_2004_cis_require_snmp_server: false
 
-# Set's postfix to act in local-only mode.
+# To avoid setting postfix to act in local-only mode. Define as `false`  if postfix is required act in local-only mode.
 ubuntu_2004_cis_require_mail_server: true
 
 # Set to `true` if RSYNC is required.

--- a/tasks/section_02.yml
+++ b/tasks/section_02.yml
@@ -346,7 +346,7 @@
   notify:
     - postfix restart
   when:
-    - ubuntu_2004_cis_require_mail_server
+    - not ubuntu_2004_cis_require_mail_server
     - "'postfix' in ansible_facts.packages"
     - ubuntu_2004_cis_section2_rule_2_1_15
     - ubuntu_2004_cis_section2


### PR DESCRIPTION
- Change to when condition for execution of task `2.1.15 | Ensure mail transfer agent is configured for local-only mode` as identified by @gitbock  in ISSUE #14 