### PR TITLE
Fix role metadata and disable Rule 1.1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Changes/Fixes/Additions/Removals addressed in Releases. Dates are in MM/DD/YYYY format.
 
+## [3.1.0](https://github.com/darkwizard242/cis_ubuntu_2004/releases/tag/3.1.0) - 02/23/2022
+
+### Fixed
+
+- Rule 1.8.1 package name correction by @jodlajodla in <https://github.com/darkwizard242/cis_ubuntu_2004/pull/16>
+- Fix role metadata and disable Rule 1.1.1.6 by @darkwizard242 in <https://github.com/darkwizard242/cis_ubuntu_2004/pull/17>
+
 ## [3.0.0](https://github.com/darkwizard242/cis_ubuntu_2004/releases/tag/3.0.0) - 01/03/2022
 
 ### Fixed

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: cis_ubuntu_2004
-  author: Ali Muhammad
+  author: darkwizard242
   description: Role to apply CIS Benchmark for Ubuntu Linux 20.04 LTS.
   company: none
   license: MIT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Role to apply CIS Benchmark for Ubuntu Linux 20.04 LTS.
   company: none
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.10
 
   platforms:
     - name: Ubuntu

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,6 +10,9 @@
     # To skip any long running tasks not required during development
     skip_for_development: true
 
+    # DISABLE 1.1.1.6 as it results with error | modprobe: FATAL: Module squashfs is builtin.
+    ubuntu_2004_cis_section1_rule_1_1_1_6: false
+
     # To set ipv6 as required .... To use ufw is as the firewall
     ubuntu_2004_cis_require_ipv6: true
     ubuntu_2004_cis_firewall: ufw

--- a/playbook-examples/playbook_with_custom_firewall_changes.yml
+++ b/playbook-examples/playbook_with_custom_firewall_changes.yml
@@ -9,6 +9,9 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
+    # DISABLE 1.1.1.6 as it results with error | modprobe: FATAL: Module squashfs is builtin.
+    ubuntu_2004_cis_section1_rule_1_1_1_6: false
+
     # To set ipv6 as required .... To use ufw is as the firewall
     ubuntu_2004_cis_firewall: ufw
 

--- a/playbook-examples/playbook_with_defaults.yml
+++ b/playbook-examples/playbook_with_defaults.yml
@@ -8,3 +8,6 @@
     - cis_ubuntu_2004
   vars:
     ansible_python_interpreter: /usr/bin/python3
+
+    # DISABLE 1.1.1.6 as it results with error | modprobe: FATAL: Module squashfs is builtin.
+    ubuntu_2004_cis_section1_rule_1_1_1_6: false

--- a/playbook-examples/playbook_with_ipv6.yml
+++ b/playbook-examples/playbook_with_ipv6.yml
@@ -9,3 +9,6 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
     ubuntu_2004_cis_require_ipv6: true
+
+    # DISABLE 1.1.1.6 as it results with error | modprobe: FATAL: Module squashfs is builtin.
+    ubuntu_2004_cis_section1_rule_1_1_1_6: false

--- a/playbook-examples/playbook_with_ufw.yml
+++ b/playbook-examples/playbook_with_ufw.yml
@@ -9,3 +9,6 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
     ubuntu_2004_cis_firewall: ufw
+
+    # DISABLE 1.1.1.6 as it results with error | modprobe: FATAL: Module squashfs is builtin.
+    ubuntu_2004_cis_section1_rule_1_1_1_6: false


### PR DESCRIPTION
- Set `min_ansible_version` in Role's metadata to 2.10 as the minimum ansible version for `cis_ubuntu_2004` role
- Set `author` in Role's metadata to `darkwizard242`
- Disable `ubuntu_2004_cis_section1_rule_1_1_1_6` in playbook examples and in molecule's converge playbook.