### PR TITLE
Add missing remediation for 5.5.4

### DIFF
--- a/defaults/main/section_05.yml
+++ b/defaults/main/section_05.yml
@@ -494,6 +494,8 @@ ubuntu_2004_cis_section5_rule_5_5_4: true
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_path: /etc/login.defs
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_line: "UMASK 027"
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_regexp: ^UMASK.*
+ubuntu_2004_cis_section5_rule_5_5_4_params_login_line_2: "USERGROUPS_ENAB no"
+ubuntu_2004_cis_section5_rule_5_5_4_params_login_regexp_2: ^USERGROUPS_ENAB.*
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_state: present
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_owner: root
 ubuntu_2004_cis_section5_rule_5_5_4_params_login_group: root

--- a/tasks/section_05.yml
+++ b/tasks/section_05.yml
@@ -967,6 +967,16 @@
         group: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_group }}"
         mode: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_mode }}"
 
+    - name: "5.5.4| Ensure USERGROUPS_ENAB is no (Automated) | Configure USERGROUPS_ENAB in /etc/login.defs"
+      lineinfile:
+        path: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_path }}"
+        line: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_line_2 }}"
+        regexp: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_regexp_2 }}"
+        state: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_state }}"
+        owner: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_owner }}"
+        group: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_group }}"
+        mode: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_login_mode }}"
+
     - name: "5.5.4| Ensure default user umask is 027 or more restrictive (Automated) | Configure umask in login.defs in /etc/pam.d/common-session"
       lineinfile:
         path: "{{ ubuntu_2004_cis_section5_rule_5_5_4_params_common_session_path }}"


### PR DESCRIPTION
## Fix

- configures `USERGROUPS_ENAB no`

Per Page 456 of CIS_Ubuntu_Linux_20.04_LTS_Benchmark_v1.1.0-1.pdf:

### Remediation
Follow one of the following methods to set the default user umask:
Edit `/etc/login.defs` and edit the UMASK and USERGROUPS_ENAB lines as follows:
```
UMASK 027
USERGROUPS_ENAB no
```
Edit `/etc/pam.d/common-session` and add or edit the following:
```
session optional             pam_umask.so
```